### PR TITLE
Fix script name when path is given

### DIFF
--- a/sshtool.go
+++ b/sshtool.go
@@ -194,7 +194,7 @@ func getUniqueScriptName(script string) string {
 	if err != nil {
 		uniqueStr = fmt.Sprintf("%d", time.Now().UnixNano())
 	}
-	return fmt.Sprintf("__sshtool_%s_%s", uniqueStr, script)
+	return fmt.Sprintf("__sshtool_%s_%s", uniqueStr, filepath.Base(script))
 }
 
 func runScript(machine *target, sshOptions []string, script string, scriptArgs []string, output chan<- string, errors chan<- error) error {

--- a/sshtool_test.go
+++ b/sshtool_test.go
@@ -28,14 +28,15 @@ func testMakeUuidOnce(t *testing.T) {
 
 func TestGetUniqueScriptName(t *testing.T) {
 	script := "foo-bar.sh"
+	scriptPath := "foo/" + script
 	expectedFormat := fmt.Sprintf("^__sshtool_[^_]+_%s$", regexp.QuoteMeta(script))
-	uniqueName := getUniqueScriptName(script)
+	uniqueName := getUniqueScriptName(scriptPath)
 	match, _ := regexp.MatchString(expectedFormat, uniqueName)
 	if !match {
 		t.Fatal("Uniquified script name does not match expected format", uniqueName)
 	}
 	// Fails with probability 2^-128 for random uuids
-	uniqueName2 := getUniqueScriptName(script)
+	uniqueName2 := getUniqueScriptName(scriptPath)
 	if uniqueName == uniqueName2 {
 		t.Fatal("Uniquified script name not unique", uniqueName, uniqueName2)
 	}
@@ -43,5 +44,4 @@ func TestGetUniqueScriptName(t *testing.T) {
 	if !match {
 		t.Fatal("Unique-ified script name does not match expected format", uniqueName2)
 	}
-
 }


### PR DESCRIPTION
Was previously inserting the entire path into the name of the script on the remote host (bug introduced in #1).