### PR TITLE
Fix filename too long error when passing many targets

### DIFF
--- a/sshtool.go
+++ b/sshtool.go
@@ -290,7 +290,7 @@ func loadMachines(targets string) []target {
 		fmt.Printf("[sshtool] Loading targets from %s\n", targets)
 	}
 	var lines []string
-	if _, err := os.Stat(targets); os.IsNotExist(err) {
+	if _, err := os.Stat(targets); err != nil {
 		lines = strings.Split(targets, ",")
 	} else {
 		file, err := os.Open(targets)


### PR DESCRIPTION
When parsing the targets parameter, the tool tries to stat the
argument to check whether it should treat it as filename for a targets
file.
The parameter was only considered a comma separated targets list if stat
returned an IsNotExist-errors. In case of other stat errors (like
filename too long), the tool still tried to open the targets list as
file.